### PR TITLE
Fixed an issue with line numbers incrementing for WebSocket or EventSource connections

### DIFF
--- a/.changeset/sour-clouds-listen.md
+++ b/.changeset/sour-clouds-listen.md
@@ -1,0 +1,5 @@
+---
+'@zwidekalanga/svelte-lazylog': patch
+---
+
+Fixed an issue where line numbers were not incrementing correctly when using WebSocket or EventSource connections. This was caused by a mismatch between the updated `processText` function signature and its call sites in the LazyLog component.


### PR DESCRIPTION
Fixed an issue where line numbers were not incrementing correctly when using WebSocket or EventSource connections. This was caused by a mismatch between the updated  function signature and its call sites in the LazyLog component.

## Description

<!-- Provide a clear and concise description of the changes introduced by this PR -->

## Type of Change

<!-- Please check the one that applies to this PR using "x" -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📝 Documentation update
- [ ] 🧹 Code refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [ ] 🤖 Build/CI pipeline changes
- [ ] 🔄 Other (please describe):

## Related Issues

<!-- Please link any related issues here. Use the syntax: "Fixes #123" or "Relates to #123" -->

## Testing

<!-- Describe the tests you've added or the testing you've performed -->

- [ ] Added or updated unit tests
- [ ] Added or updated E2E tests
- [x] Manually tested changes

## Checklist

<!-- Please check all that apply using "x" -->

- [ ] My code follows the code style of this project
- [ ] I have run `yarn lint` and fixed any issues
- [ ] I have run `yarn test` and all tests pass
- [ ] I have created a changeset using `yarn changeset` (required for version bumps)
- [ ] I have updated the documentation accordingly (if applicable)
- [ ] My changes don't introduce any new warnings or errors

## Screenshots or Additional Context

<!-- If applicable, add screenshots or additional context to help explain your changes -->
